### PR TITLE
Removal of reasonForLeaving from example

### DIFF
--- a/examples/backgroundcheck-example.json
+++ b/examples/backgroundcheck-example.json
@@ -26,7 +26,6 @@
           "startDate": "1964-03-01T00:00:00",
           "endDate": "1968-02-01T00:00:00",
           "managerName": "sdfga",
-          "reasonForLeaving": "asdfhdfsj",
           "responsibilities": "adfshgh",
           "employmentType": "PREVIOUSLY_EMPLOYED"
         }


### PR DESCRIPTION
I can't see a valid case where this would be relevant in relation to a background check request.